### PR TITLE
Add Caterpie Find A attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -3,6 +3,7 @@ use rand::Rng;
 
 use crate::{
     attack_ids::AttackId,
+    attacks::caterpie::caterpie_find_a,
     effects::{CardEffect, TurnEffect},
     hooks::get_damage_from_attack,
     types::{EnergyType, StatusCondition},
@@ -97,6 +98,7 @@ fn forecast_effect_attack(
     match attack_id {
         AttackId::A1003VenusaurMegaDrain => self_heal_attack(30, index),
         AttackId::A1004VenusaurExGiantBloom => self_heal_attack(30, index),
+        AttackId::A1005CaterpieFindA => caterpie_find_a(acting_player, state),
         AttackId::A1013VileplumeSoothingScent => damage_status_attack(80, StatusCondition::Asleep),
         AttackId::A1017VenomothPoisonPowder => damage_status_attack(30, StatusCondition::Poisoned),
         AttackId::A1022ExeggutorStomp => probabilistic_damage_attack(vec![0.5, 0.5], vec![30, 60]),

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,9 +1,9 @@
 mod apply_abilities_action;
 mod apply_action;
-mod apply_action_helpers;
+pub(crate) mod apply_action_helpers;
 mod apply_attack_action;
 mod apply_trainer_action;
-mod mutations;
+pub(crate) mod mutations;
 mod shared_mutations;
 mod types;
 

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 pub enum AttackId {
     A1003VenusaurMegaDrain,
     A1004VenusaurExGiantBloom,
+    A1005CaterpieFindA,
     A1013VileplumeSoothingScent,
     A1017VenomothPoisonPowder,
     A1022ExeggutorStomp,
@@ -95,6 +96,7 @@ lazy_static::lazy_static! {
         let mut m = HashMap::new();
         m.insert(("A1 003", 0), AttackId::A1003VenusaurMegaDrain);
         m.insert(("A1 004", 1), AttackId::A1004VenusaurExGiantBloom);
+        m.insert(("A1 005", 0), AttackId::A1005CaterpieFindA);
         m.insert(("A1 013", 0), AttackId::A1013VileplumeSoothingScent);
         m.insert(("A1 017", 0), AttackId::A1017VenomothPoisonPowder);
         m.insert(("A1 022", 0), AttackId::A1022ExeggutorStomp);

--- a/src/attacks/caterpie.rs
+++ b/src/attacks/caterpie.rs
@@ -1,0 +1,50 @@
+use crate::{
+    actions::{
+        apply_action_helpers::{Mutations, Probabilities},
+        mutations::{active_damage_effect_doutcome, active_damage_effect_mutation},
+    },
+    types::{Card, EnergyType},
+    State,
+};
+
+/// Caterpie's "Find a" attack.
+///
+/// Moves a random Grass-type Pokémon from the deck to the player's hand.
+/// Requires one Colorless energy to be attached to Caterpie but does not
+/// discard it. If no Grass Pokémon are found, the deck is shuffled.
+pub(crate) fn caterpie_find_a(
+    acting_player: usize,
+    state: &State,
+) -> (Probabilities, Mutations) {
+    let grass_cards: Vec<Card> = state.decks[acting_player]
+        .cards
+        .iter()
+        .filter(|c| c.get_type() == Some(EnergyType::Grass))
+        .cloned()
+        .collect();
+
+    if grass_cards.is_empty() {
+        return active_damage_effect_doutcome(0, |rng, state, action| {
+            state.decks[action.actor].shuffle(false, rng);
+        });
+    }
+
+    let probabilities = vec![1.0 / grass_cards.len() as f64; grass_cards.len()];
+    let mutations = grass_cards
+        .into_iter()
+        .map(|card| {
+            active_damage_effect_mutation(0, {
+                move |rng, state, action| {
+                    let deck = &mut state.decks[action.actor];
+                    if let Some(pos) = deck.cards.iter().position(|c| c == &card) {
+                        deck.cards.remove(pos);
+                        state.hands[action.actor].push(card.clone());
+                    }
+                    deck.shuffle(false, rng);
+                }
+            })
+        })
+        .collect();
+
+    (probabilities, mutations)
+}

--- a/src/attacks/mod.rs
+++ b/src/attacks/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod caterpie;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod ability_ids;
 pub mod actions;
 mod attack_ids;
+mod attacks;
 pub mod card_ids;
 pub mod card_logic;
 pub mod database;

--- a/tests/caterpie_attack_test.rs
+++ b/tests/caterpie_attack_test.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    players::{EndTurnPlayer, Player},
+    types::{Card, EnergyType, PlayedCard},
+    Deck, Game, State,
+};
+
+fn setup_state(deck_a: &Deck, deck_b: &Deck, caterpie_hp: u32, caterpie_card: &Card) -> State {
+    let mut state = State::default();
+    state.decks[0] = deck_a.clone();
+    state.decks[1] = deck_b.clone();
+    state.turn_count = 1;
+    let active = PlayedCard::new(
+        caterpie_card.clone(),
+        caterpie_hp,
+        caterpie_hp,
+        vec![EnergyType::Colorless],
+        false,
+        vec![],
+    );
+    state.in_play_pokemon[0][0] = Some(active);
+    state
+}
+
+#[test]
+fn test_caterpie_attack_retrieves_grass_pokemon() {
+    let bulbasaur = get_card_by_enum(CardId::A1001Bulbasaur);
+    let ivysaur = get_card_by_enum(CardId::A1002Ivysaur);
+    let charmander = get_card_by_enum(CardId::A1033Charmander);
+    let caterpie = get_card_by_enum(CardId::A1005Caterpie);
+
+    let mut deck_a = Deck::default();
+    deck_a.cards = vec![bulbasaur.clone(), ivysaur.clone(), charmander.clone()];
+    let deck_b = Deck::default();
+
+    let hp = match &caterpie {
+        Card::Pokemon(p) => p.hp,
+        _ => 0,
+    };
+
+    let state = setup_state(&deck_a, &deck_b, hp, &caterpie);
+
+    let players: Vec<Box<dyn Player>> = vec![
+        Box::new(EndTurnPlayer { deck: deck_a.clone() }),
+        Box::new(EndTurnPlayer { deck: deck_b.clone() }),
+    ];
+    let mut game = Game::from_state(state, players, 0);
+
+    let action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&action);
+
+    let result_state = game.get_state_clone();
+    assert_eq!(result_state.hands[0].len(), 1);
+    let card_drawn = &result_state.hands[0][0];
+    if let Card::Pokemon(p) = card_drawn {
+        assert_eq!(p.energy_type, EnergyType::Grass);
+    } else {
+        panic!("Expected Pokémon card");
+    }
+    assert_eq!(result_state.decks[0].cards.len(), 2);
+    let energy = &result_state.in_play_pokemon[0][0]
+        .as_ref()
+        .unwrap()
+        .attached_energy;
+    assert_eq!(energy, &vec![EnergyType::Colorless]);
+}
+
+#[test]
+fn test_caterpie_attack_probabilities() {
+    let bulbasaur = get_card_by_enum(CardId::A1001Bulbasaur);
+    let ivysaur = get_card_by_enum(CardId::A1002Ivysaur);
+    let charmander = get_card_by_enum(CardId::A1033Charmander);
+    let caterpie = get_card_by_enum(CardId::A1005Caterpie);
+
+    let mut deck_a = Deck::default();
+    deck_a.cards = vec![bulbasaur.clone(), ivysaur.clone(), charmander.clone()];
+    let deck_b = Deck::default();
+
+    let hp = match &caterpie {
+        Card::Pokemon(p) => p.hp,
+        _ => 0,
+    };
+
+    let iterations = 200;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    for i in 0..iterations {
+        let state = setup_state(&deck_a, &deck_b, hp, &caterpie);
+        let players: Vec<Box<dyn Player>> = vec![
+            Box::new(EndTurnPlayer { deck: deck_a.clone() }),
+            Box::new(EndTurnPlayer { deck: deck_b.clone() }),
+        ];
+        let mut game = Game::from_state(state, players, i as u64);
+        let action = Action {
+            actor: 0,
+            action: SimpleAction::Attack(0),
+            is_stack: false,
+        };
+        game.apply_action(&action);
+        let card = game.get_state_clone().hands[0][0].get_name();
+        *counts.entry(card).or_default() += 1;
+    }
+
+    // Should never draw the non-Grass card
+    assert!(counts.get(&charmander.get_name()).unwrap_or(&0) == &0);
+
+    let bulba = *counts.get(&bulbasaur.get_name()).unwrap_or(&0) as f64;
+    let ivy = *counts.get(&ivysaur.get_name()).unwrap_or(&0) as f64;
+    let total = bulba + ivy;
+    assert_eq!(total as usize, iterations);
+
+    let prob_bulba = bulba / total;
+    let prob_ivy = ivy / total;
+    // Both probabilities should be roughly equal
+    assert!((prob_bulba - 0.5).abs() < 0.2);
+    assert!((prob_ivy - 0.5).abs() < 0.2);
+}


### PR DESCRIPTION
## Summary
- add Caterpie Find A attack identifier
- implement attack logic to draw a random Grass Pokémon without discarding energy
- register attack and add tests for retrieval and probability

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68960a38988083258d55e26662a92a7b