### PR TITLE
Add Victreebel Fragrance Trap ability

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -10,6 +10,7 @@ pub enum AbilityId {
     A3122SolgaleoExRisingRoad,
     A3a027ShiinoticIlluminate,
     A3b034SylveonExHappyRibbon,
+    A1020VictreebelFragranceTrap,
 }
 
 // Create a static HashMap for fast (pokemon, index) lookup
@@ -19,6 +20,7 @@ lazy_static::lazy_static! {
         m.insert("A1 007", AbilityId::A1007Butterfree);
         m.insert("A1 177", AbilityId::A1177Weezing);
         m.insert("A1 132", AbilityId::A1132Gardevoir);
+        m.insert("A1 020", AbilityId::A1020VictreebelFragranceTrap);
         m.insert("A2a 071", AbilityId::A2a071Arceus);
         m.insert("A2a 086", AbilityId::A2a071Arceus);
         m.insert("A2a 095", AbilityId::A2a071Arceus);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -31,6 +31,7 @@ pub(crate) fn forecast_ability(
         AbilityId::A3122SolgaleoExRisingRoad => rising_road(index),
         AbilityId::A3a027ShiinoticIlluminate => pokeball_outcomes(action.actor, state),
         AbilityId::A3b034SylveonExHappyRibbon => panic!("Happy Ribbon cant be used on demand"),
+        AbilityId::A1020VictreebelFragranceTrap => fragrance_trap(),
     }
 }
 
@@ -71,5 +72,22 @@ fn rising_road(index: usize) -> (Probabilities, Mutations) {
         debug!("Solgaleo's ability: Switching with active Pokemon");
         let choices = vec![SimpleAction::Activate { in_play_idx: index }];
         state.move_generation_stack.push((action.actor, choices));
+    }))
+}
+
+fn fragrance_trap() -> (Probabilities, Mutations) {
+    ability_doutcome(ability_mutation(|_, state, action| {
+        // If this Pokémon is in the Active Spot, once during your turn, you may switch in 1 of your opponent's Benched Basic Pokémon to the Active Spot.
+        debug!("Victreebel's ability: Fragrance Trap");
+        let opponent = (action.actor + 1) % 2;
+        let mut choices = Vec::new();
+        for (in_play_idx, pokemon) in state.enumerate_bench_pokemon(opponent) {
+            if pokemon.card.is_basic() {
+                choices.push(SimpleAction::ForceSwitchOpponent { in_play_idx });
+            }
+        }
+        if !choices.is_empty() {
+            state.move_generation_stack.push((action.actor, choices));
+        }
     }))
 }

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -43,6 +43,7 @@ pub fn forecast_action(state: &State, action: &Action) -> (Probabilities, Mutati
         | SimpleAction::AttachTool { .. }
         | SimpleAction::Evolve(_, _)
         | SimpleAction::Activate { .. }
+        | SimpleAction::ForceSwitchOpponent { .. }
         | SimpleAction::Retreat(_)
         | SimpleAction::ApplyDamage { .. }
         | SimpleAction::Heal { .. }
@@ -106,6 +107,10 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
         }
         SimpleAction::Activate { in_play_idx } => {
             apply_retreat(action.actor, state, *in_play_idx, true);
+        }
+        SimpleAction::ForceSwitchOpponent { in_play_idx } => {
+            let opponent = (action.actor + 1) % 2;
+            apply_retreat(opponent, state, *in_play_idx, true);
         }
         SimpleAction::Retreat(position) => {
             apply_retreat(action.actor, state, *position, false);

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -55,6 +55,10 @@ pub enum SimpleAction {
     Activate {
         in_play_idx: usize,
     },
+    /// Force the opponent to switch the specified bench Pokémon with their active Pokémon.
+    ForceSwitchOpponent {
+        in_play_idx: usize,
+    },
     Noop, // No operation, used to have the user say "no" to a question
 }
 
@@ -101,6 +105,9 @@ impl fmt::Display for SimpleAction {
                 write!(f, "ApplyDamage({targets_str})")
             }
             SimpleAction::Activate { in_play_idx } => write!(f, "Activate({in_play_idx})"),
+            SimpleAction::ForceSwitchOpponent { in_play_idx } => {
+                write!(f, "ForceSwitchOpponent({in_play_idx})")
+            }
             SimpleAction::Noop => write!(f, "Noop"),
         }
     }

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -30,5 +30,6 @@ fn can_use_ability((in_play_index, card): &(usize, &PlayedCard)) -> bool {
         AbilityId::A3a027ShiinoticIlluminate => !card.ability_used,
         AbilityId::A2a071Arceus => false,
         AbilityId::A3b034SylveonExHappyRibbon => false,
+        AbilityId::A1020VictreebelFragranceTrap => is_active && !card.ability_used,
     }
 }

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -57,6 +57,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::EndTurn => 1,
         SimpleAction::Heal { .. } => 5,
         SimpleAction::Activate { .. } => 1,
+        SimpleAction::ForceSwitchOpponent { .. } => 10,
         SimpleAction::Noop => 0, // No operation has no weight
     }
 }

--- a/tests/victreebel_ability_test.rs
+++ b/tests/victreebel_ability_test.rs
@@ -1,0 +1,52 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    generate_possible_actions,
+    players::{EndTurnPlayer, Player},
+    types::{Card, PlayedCard},
+    Deck, Game, State,
+};
+
+#[test]
+fn victreebel_fragrance_trap_switches_basic_from_opponent() {
+    let victreebel = get_card_by_enum(CardId::A1020Victreebel);
+    let charmander = get_card_by_enum(CardId::A1033Charmander);
+    let bulbasaur = get_card_by_enum(CardId::A1001Bulbasaur);
+    let ivysaur = get_card_by_enum(CardId::A1002Ivysaur);
+
+    let mut state = State::default();
+    state.turn_count = 1;
+    let hp_vic = match &victreebel { Card::Pokemon(p) => p.hp, _ => 0 };
+    state.in_play_pokemon[0][0] = Some(PlayedCard::new(victreebel.clone(), hp_vic, hp_vic, vec![], false, vec![]));
+
+    let hp_char = match &charmander { Card::Pokemon(p) => p.hp, _ => 0 };
+    state.in_play_pokemon[1][0] = Some(PlayedCard::new(charmander.clone(), hp_char, hp_char, vec![], false, vec![]));
+    let hp_bulba = match &bulbasaur { Card::Pokemon(p) => p.hp, _ => 0 };
+    state.in_play_pokemon[1][1] = Some(PlayedCard::new(bulbasaur.clone(), hp_bulba, hp_bulba, vec![], false, vec![]));
+    let hp_ivy = match &ivysaur { Card::Pokemon(p) => p.hp, _ => 0 };
+    state.in_play_pokemon[1][2] = Some(PlayedCard::new(ivysaur.clone(), hp_ivy, hp_ivy, vec![], false, vec![]));
+
+    let players: Vec<Box<dyn Player>> = vec![
+        Box::new(EndTurnPlayer { deck: Deck::default() }),
+        Box::new(EndTurnPlayer { deck: Deck::default() }),
+    ];
+    let mut game = Game::from_state(state, players, 0);
+
+    let action = Action { actor: 0, action: SimpleAction::UseAbility(0), is_stack: false };
+    game.apply_action(&action);
+
+    let state = game.get_state_clone();
+    let (actor, actions) = generate_possible_actions(&state);
+    assert_eq!(actor, 0);
+    assert_eq!(actions.len(), 1);
+    assert!(matches!(actions[0].action, SimpleAction::ForceSwitchOpponent { in_play_idx: 1 }));
+
+    let switch_action = Action { actor: 0, action: SimpleAction::ForceSwitchOpponent { in_play_idx: 1 }, is_stack: true };
+    game.apply_action(&switch_action);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.in_play_pokemon[1][0].as_ref().unwrap().card.get_name(), bulbasaur.get_name());
+    assert_eq!(state.in_play_pokemon[1][1].as_ref().unwrap().card.get_name(), charmander.get_name());
+    assert_eq!(state.in_play_pokemon[1][2].as_ref().unwrap().card.get_name(), ivysaur.get_name());
+}


### PR DESCRIPTION
## Summary
- implement Victreebel's Fragrance Trap ability to pull an opponent's Benched Basic Pokémon active
- add new ForceSwitchOpponent action type and wire it through ability handling and players
- test Victreebel's ability

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689619ab08fc8325b6f07ae2d9331690